### PR TITLE
🩹 Two minor fixes -- PORT and scritps/sign.ts

### DIFF
--- a/script/signer.ts
+++ b/script/signer.ts
@@ -1,4 +1,4 @@
-import starknet from 'starknet';
+import * as starknet from 'starknet';
 
 const starkCheckSignerPk = 1673888886562;
 const keyPair = starknet.ec.getKeyPair(starkCheckSignerPk);

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,7 +44,7 @@ router.use((_, res) => {
 });
 
 /** Server */
-const PORT = process.env.PORT ?? '6060';
+const PORT = process.env.PORT || '6060';
 router.listen(PORT, () => {
   console.log(`The server is running on port ${PORT}`);
 });


### PR DESCRIPTION
Commit 0219814:

> As environment variables are not typed, if the PORT environment variable
is present in the .env file but not set (PORT=), the process.env.PORT will
be an empty string not an undefined. This is not a valid port number,
so we need to handle this case. To manage this I switched from the nullish
coalescing operator to the logical OR operator in the condition.

Commit 994d6b3:
> Import reorg introduced by #96976d2 was not correct, this commit fixes it.

This error was silent as the script is not tested or even check during the remote/local CI. Probably something we want to.