### PR TITLE
"improve" RPCProvider mocking

### DIFF
--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -2,27 +2,51 @@
 import app from '../src/app';
 import supertest from 'supertest';
 import { readFileSync } from 'fs';
+import { RpcProviderOptions, RPC } from 'starknet';
 
 const events = JSON.parse(readFileSync('test/getPolicies/events.json', 'utf8'));
 const policyFormatted = JSON.parse(
   readFileSync('test/getPolicies/policyFormatted.json', 'utf8')
 );
+
+// create a mock function that will replace the real implementation of
+// (new RpcProvider(...)).getEvents. keeping the reference of the mocked
+// function allow us to update the return value of the mocked function
+// for each test case
+const mockedGetEvents = jest.fn();
+
 // mock relevant object in starknetjs
 jest.mock('starknet', () => ({
   // transform the module to es6 module, to avoid the read-only allocation error
   __esModule: true,
   // import the actual module to make sure we don't mock the actual implementation of starknetjs
   ...jest.requireActual('starknet'),
-  // mock the RpcProvider class using a minimalist implementation
-  // this mock is required because the provider fire the fetchEndpoint method on instantiation
-  // that request the RPC endpoint
-  RpcProvider: jest.fn().mockReturnValue({
-    getEvents: jest
-      .fn()
-      .mockImplementationOnce((_) => events)
-      .mockImplementationOnce((_) => ({
-        events: [],
-      })),
+  // mock the RpcProvider class using a minimalist class that mock the important methods
+  RpcProvider: jest.fn().mockImplementation(() => {
+    class MockedRpcProvider extends jest.requireActual('starknet').RpcProvider {
+      constructor(args: RpcProviderOptions) {
+        super(args);
+      }
+
+      async getEvents(
+        eventsFilter: RPC.EventFilter
+      ): Promise<RPC.GetEventsResponse> {
+        // everytime the getEvents method is called, call the mockedGetEvents function
+        // and return the value returned by the mocked function
+        return mockedGetEvents(eventsFilter);
+      }
+
+      // intercept all the requests made by the initial implementation and return a dumb value
+      async fetchEndpoint() {
+        // TODO: write a switch for all the possible endpoint and return coherent values
+        return new Promise((resolve) => resolve(true));
+      }
+    }
+
+    // return a new instance of the mocked class instead of the actual implementation
+    return new MockedRpcProvider({
+      nodeUrl: 'https://starknet-fakenetwork.infura.io/v3/fake-key',
+    });
   }),
 }));
 
@@ -45,6 +69,9 @@ describe('server', () => {
 
   describe('/getPolicies', () => {
     test('OK', async () => {
+      // mock the getEvents method to return the full list of events
+      mockedGetEvents.mockReturnValue(events);
+
       const response = await request
         .get(
           '/starkchecks/getPolicies/0x038b6f1f5e39f5965a28ff2624ab941112d54fe71b8bf1283f565f5c925566c0'
@@ -57,6 +84,9 @@ describe('server', () => {
     });
 
     test('No policy found', async () => {
+      // mock the getEvents method to return an empty array
+      mockedGetEvents.mockReturnValue({ events: [] });
+
       const response = await request
         .get(
           '/starkchecks/getPolicies/0x038b6f1f5e39f5965a28ff2624ab941112d54fe71b8bf1283f565f5c925566c0'


### PR DESCRIPTION
Using a custom class implementation that extends the RPCProvider class, we now have more control on the mocking of getEvents and a way to intercept all http requests made by the provider. I would say "improve" is a bit exagerated in this case but this implementation is more flexible and give us the foundation to mock any methods by tests.